### PR TITLE
61 error handling on edit

### DIFF
--- a/Satori/Pages/StandUp/Components/EditStandUpDialog.razor
+++ b/Satori/Pages/StandUp/Components/EditStandUpDialog.razor
@@ -1,11 +1,13 @@
 ﻿@using Satori.AppServices.Extensions
 @using Satori.AppServices.Models
 @using Satori.AppServices.Services
+@using Satori.AppServices.Services.Abstractions
 @using Satori.Pages.StandUp.Components.ViewModels
 
 @inject IConnectionSettingsStore ConnectionSettingsStore
 @inject StandUpService StandUpService
 @inject WorkItemUpdateService WorkItemUpdateService
+@inject IAlertService AlertService
 
 @if(TimeEntries.Length == 0)
 {

--- a/Satori/Pages/StandUp/Components/EditStandUpDialog.razor.cs
+++ b/Satori/Pages/StandUp/Components/EditStandUpDialog.razor.cs
@@ -2,6 +2,7 @@
 using CodeMonkeyProjectiles.Linq;
 using Microsoft.AspNetCore.Components;
 using Satori.AppServices.Services.CommentParsing;
+using Satori.AppServices.ViewModels;
 using Satori.AppServices.ViewModels.DailyStandUps;
 using Satori.Pages.StandUp.Components.ViewModels;
 using Satori.Utilities;
@@ -185,8 +186,8 @@ public partial class EditStandUpDialog
     {
         try
         {
-        await SaveAzureDevOpsTaskAsync();
-        await SaveKimaiTimeEntriesAsync();
+            await SaveAzureDevOpsTaskAsync();
+            await SaveKimaiTimeEntriesAsync();
         }
         catch (Exception ex)
         {
@@ -204,6 +205,11 @@ public partial class EditStandUpDialog
         foreach (var comment in Comments.OfType<WorkItemCommentViewModel>().Where(x => x.WorkItem != null))
         {
             var workItem = comment.WorkItem ?? throw new InvalidOperationException();
+            if (workItem.AssignedTo != Person.Me)
+            {
+                return;  //Nothing to save.  Can't save other person's work item.
+            }
+
             var remainingTime = comment.UnexportedTime + comment.SelectedTime + TimeSpan.FromHours(comment.TimeRemainingInput);
 
             await WorkItemUpdateService.UpdateTaskAsync(workItem, comment.State, remainingTime);

--- a/Satori/Pages/StandUp/Components/EditStandUpDialog.razor.cs
+++ b/Satori/Pages/StandUp/Components/EditStandUpDialog.razor.cs
@@ -183,8 +183,16 @@ public partial class EditStandUpDialog
 
     private async Task SaveClickAsync()
     {
+        try
+        {
         await SaveAzureDevOpsTaskAsync();
         await SaveKimaiTimeEntriesAsync();
+        }
+        catch (Exception ex)
+        {
+            AlertService.BroadcastAlert(ex);
+            return;
+        }
 
         DialogVisible = VisibleCssClass.Hidden;
         await OnSaved.InvokeAsync();


### PR DESCRIPTION
- On the Stand-up Edit dialog's Save button unexpected errors are shown as an Alert banner
- Satori will no longer attempt to save changes to another person's Task card.  Attempts were failing due to proper guards in the business logic, but the UI will stop attempting this now.