### PR TITLE
Release candidate

### DIFF
--- a/Satori.AppServices.Tests/TestDoubles/Kimai/TestKimaiServer.cs
+++ b/Satori.AppServices.Tests/TestDoubles/Kimai/TestKimaiServer.cs
@@ -88,7 +88,12 @@ internal class TestKimaiServer
         {
             throw new HttpRequestException("Bad Response: 404 - Not Found", inner: null, HttpStatusCode.NotFound);
         }
-        
+
+        foreach (var entry in entries.Where(x => x.IsOverlapping))
+        {
+            entry.IsOverlapping = false;
+        }
+
         return entries.ToArray();
     }
 

--- a/Satori.AppServices.Tests/WorkItemUpdateTests/UpdateTaskTests.cs
+++ b/Satori.AppServices.Tests/WorkItemUpdateTests/UpdateTaskTests.cs
@@ -71,7 +71,6 @@ public class UpdateTaskTests
     public async Task ASmokeTest_NoChanges_NotUpdated()
     {
         //Arrange
-        
         var task = BuildTask();
 
         //Verify BuildTask behaviour

--- a/Satori.AppServices/Services/StandUpService.cs
+++ b/Satori.AppServices/Services/StandUpService.cs
@@ -58,7 +58,6 @@ public partial class StandUpService(
         await Task.WhenAll(getUserTask, getTimeSheetTask);
 
         var timeSheet = getTimeSheetTask.Result;
-        SetIsOverlapping(timeSheet);
         var period = new PeriodSummary()
         {
             TotalTime = GetDuration(timeSheet),
@@ -143,6 +142,8 @@ public partial class StandUpService(
                 done = true;
             }
         } while (!done);
+
+        SetIsOverlapping(timeSheet);
 
         return timeSheet;
     }

--- a/Satori.AppServices/ViewModels/DailyStandUps/ActivitySummary.cs
+++ b/Satori.AppServices/ViewModels/DailyStandUps/ActivitySummary.cs
@@ -31,4 +31,7 @@ public class ActivitySummary : ISummary
     public string? Impediments { get; set; }
     public string? Learnings { get; set; }
     public string? OtherComments { get; set; }
+
+    public override string ToString() => 
+        $"{ParentProjectSummary.ProjectName} {ActivityName} for {ParentProjectSummary.ParentDay.Date:yyyy-MM-dd}";
 }

--- a/Satori.AppServices/ViewModels/DailyStandUps/DaySummary.cs
+++ b/Satori.AppServices/ViewModels/DailyStandUps/DaySummary.cs
@@ -19,4 +19,5 @@ public class DaySummary : ISummary
     /// </summary>
     public bool IsCollapsed { get; set; }
 
+    public override string ToString() => $"Day {Date:yyyy-MM-dd}";
 }

--- a/Satori.AppServices/ViewModels/DailyStandUps/PeriodSummary.cs
+++ b/Satori.AppServices/ViewModels/DailyStandUps/PeriodSummary.cs
@@ -10,4 +10,11 @@ public class PeriodSummary : ISummary
     public bool AllExported { get; internal set; }
     public bool CanExport { get; internal set; }
     public bool IsRunning { get; internal set; }
+
+    public override string ToString()
+    {
+        var first = Days.Min(d => d.Date);
+        var last = Days.Min(d => d.Date);
+        return $"Period Summary {first:yyyy-MM-dd} to {last:yyyy-MM-dd}";
+    }
 }

--- a/Satori.AppServices/ViewModels/DailyStandUps/ProjectSummary.cs
+++ b/Satori.AppServices/ViewModels/DailyStandUps/ProjectSummary.cs
@@ -32,4 +32,6 @@ public class ProjectSummary : ISummary
     /// For the UI to control if the section is collapsed or expanded
     /// </summary>
     public bool IsCollapsed { get; set; }
+
+    public override string ToString() => $"Project {ProjectName} for {ParentDay.Date:yyyy-MM-dd}";
 }

--- a/Satori.AppServices/ViewModels/DailyStandUps/TaskSummary.cs
+++ b/Satori.AppServices/ViewModels/DailyStandUps/TaskSummary.cs
@@ -30,4 +30,7 @@ public class TaskSummary : ISummary
     public string? Impediments { get; set; }
     public string? Learnings { get; set; }
     public string? OtherComments { get; set; }
+
+    public override string ToString() =>
+        $"{ParentActivitySummary.ParentProjectSummary.ProjectName} {ParentActivitySummary.ActivityName} {Task?.Title} for {ParentActivitySummary.ParentProjectSummary.ParentDay.Date:yyyy-MM-dd}";
 }

--- a/Satori.AppServices/ViewModels/DailyStandUps/TimeEntry.cs
+++ b/Satori.AppServices/ViewModels/DailyStandUps/TimeEntry.cs
@@ -49,4 +49,5 @@ public class TimeEntry : ISummary, ITimeRange
     public string? Learnings { get; set; }
     public string? OtherComments { get; set; }
 
+    public override string ToString() => $"Time Entry {Id} {Begin:yyyy-MM-dd hh:mm}";
 }

--- a/Satori/Pages/StandUp/Components/EditStandUpDialog.razor
+++ b/Satori/Pages/StandUp/Components/EditStandUpDialog.razor
@@ -1,11 +1,13 @@
 ﻿@using Satori.AppServices.Extensions
 @using Satori.AppServices.Models
 @using Satori.AppServices.Services
+@using Satori.AppServices.Services.Abstractions
 @using Satori.Pages.StandUp.Components.ViewModels
 
 @inject IConnectionSettingsStore ConnectionSettingsStore
 @inject StandUpService StandUpService
 @inject WorkItemUpdateService WorkItemUpdateService
+@inject IAlertService AlertService
 
 @if(TimeEntries.Length == 0)
 {

--- a/Satori/Pages/StandUp/Components/EditStandUpDialog.razor.cs
+++ b/Satori/Pages/StandUp/Components/EditStandUpDialog.razor.cs
@@ -2,6 +2,7 @@
 using CodeMonkeyProjectiles.Linq;
 using Microsoft.AspNetCore.Components;
 using Satori.AppServices.Services.CommentParsing;
+using Satori.AppServices.ViewModels;
 using Satori.AppServices.ViewModels.DailyStandUps;
 using Satori.Pages.StandUp.Components.ViewModels;
 using Satori.Utilities;
@@ -183,8 +184,16 @@ public partial class EditStandUpDialog
 
     private async Task SaveClickAsync()
     {
-        await SaveAzureDevOpsTaskAsync();
-        await SaveKimaiTimeEntriesAsync();
+        try
+        {
+            await SaveAzureDevOpsTaskAsync();
+            await SaveKimaiTimeEntriesAsync();
+        }
+        catch (Exception ex)
+        {
+            AlertService.BroadcastAlert(ex);
+            return;
+        }
 
         DialogVisible = VisibleCssClass.Hidden;
         await OnSaved.InvokeAsync();
@@ -196,6 +205,11 @@ public partial class EditStandUpDialog
         foreach (var comment in Comments.OfType<WorkItemCommentViewModel>().Where(x => x.WorkItem != null))
         {
             var workItem = comment.WorkItem ?? throw new InvalidOperationException();
+            if (workItem.AssignedTo != Person.Me)
+            {
+                return;  //Nothing to save.  Can't save other person's work item.
+            }
+
             var remainingTime = comment.UnexportedTime + comment.SelectedTime + TimeSpan.FromHours(comment.TimeRemainingInput);
 
             await WorkItemUpdateService.UpdateTaskAsync(workItem, comment.State, remainingTime);


### PR DESCRIPTION
- Fixes #59 
  - Overlapping time entries are alerted on after Edit
- Fixes #61 
  - On the Stand-up Edit dialog's Save button unexpected errors are shown as an Alert banner
  - Satori will no longer attempt to save changes to another person's Task card. Attempts were failing due to proper guards in the business logic, but the UI will stop attempting this now.