### PR TITLE
Move work item counts to the right

### DIFF
--- a/Satori/Pages/PullRequests.razor
+++ b/Satori/Pages/PullRequests.razor
@@ -17,15 +17,15 @@
 
 <div class="flex-row">
     <div class="page-title">Pull Requests</div>
-    <div class="counters">
-        <span class="badge bg-primary">@FilteredPullRequests.Count()</span>
-    </div>
     <CustomerFilter Projects="Projects" OnFilterChanged="OnForFilterChanged" @ref="ForFilter" QueryParamName="for" StorageKeyName="PullRequest.For"></CustomerFilter>
     <PersonFilter Label="By" People="Authors" AllowNull="false" OnFilterChanged="OnAuthorFilterChanged" @ref="AuthorFilter" QueryParamName="by" StorageKeyName="PullRequest.By"></PersonFilter>
     <PersonFilter Label="With" People="WithPeople" AllowNull="false" OnFilterChanged="OnWithFilterChanged" @ref="WithPersonFilter" QueryParamName="with" StorageKeyName="PullRequest.With"></PersonFilter>
     <PersonFilter Label="On" People="ActionItemPeople" AllowNull="false" OnFilterChanged="OnActionItemFilterChanged" @ref="ActionItemPersonFilter" QueryParamName="on" StorageKeyName="PullRequest.On"></PersonFilter>
     <div>
         <button class="btn-header btn-refresh @InLoading" title="Refresh (Alt+F5)" @onclick="async () => await RefreshAsync()"><span class="bi bi-refresh"></span></button>
+    </div>
+    <div class="counters">
+        <span class="badge bg-primary">@FilteredPullRequests.Count()</span>
     </div>
 </div>
 

--- a/Satori/Pages/SprintBoard/SprintBoards.razor
+++ b/Satori/Pages/SprintBoard/SprintBoards.razor
@@ -23,6 +23,12 @@
 
 <div class="flex-row">
     <div class="page-title">Sprint Boards</div>
+    <CustomerFilter Projects="_projects" OnFilterChanged="ForFilterChanged" @ref="ForFilter" QueryParamName="for" StorageKeyName="SprintBoard.For"></CustomerFilter>
+    <PersonFilter Label="With" People="_workItems?.SelectMany(wi => wi.WithPeople) ?? []" OnFilterChanged="WithFilterChanged" @ref="WithPersonFilter" QueryParamName="with" StorageKeyName="SprintBoard.With"></PersonFilter>
+    <PersonFilter Label="On" People="ActionItemPeople" OnFilterChanged="ActionItemFilterChanged" @ref="ActionItemPersonFilter" QueryParamName="on" StorageKeyName="SprintBoard.On"></PersonFilter>
+    <div>
+        <button class="btn-header btn-refresh @InLoading" title="Refresh (Alt+F5)" @onclick="async () => await RefreshAsync()"><span class="bi bi-refresh"></span></button>
+    </div>
     <div class="counters">
         @if (_workItems != null)
         {
@@ -30,12 +36,6 @@
             <div class="badge bg-warning" title="In Progress">@WorkInProgressCount</div>
             <div class="badge bg-success" title="Done">@WorkItemDoneCount</div>
         }
-    </div>        
-    <CustomerFilter Projects="_projects" OnFilterChanged="ForFilterChanged" @ref="ForFilter" QueryParamName="for" StorageKeyName="SprintBoard.For"></CustomerFilter>
-    <PersonFilter Label="With" People="_workItems?.SelectMany(wi => wi.WithPeople) ?? []" OnFilterChanged="WithFilterChanged" @ref="WithPersonFilter" QueryParamName="with" StorageKeyName="SprintBoard.With"></PersonFilter>
-    <PersonFilter Label="On" People="ActionItemPeople" OnFilterChanged="ActionItemFilterChanged" @ref="ActionItemPersonFilter" QueryParamName="on" StorageKeyName="SprintBoard.On"></PersonFilter>
-    <div>
-        <button class="btn-header btn-refresh @InLoading" title="Refresh (Alt+F5)" @onclick="async () => await RefreshAsync()"><span class="bi bi-refresh"></span></button>
     </div>
     <div class="flex-center-whitespace"></div>
     <div>


### PR DESCRIPTION
Fixes #121.  Moves work item counts on the Sprint and Pull Request boards to the right, as to not interfere with changing filter controls